### PR TITLE
Function to convert oracle prices

### DIFF
--- a/contracts/mocks/Math64x61Mock.cairo
+++ b/contracts/mocks/Math64x61Mock.cairo
@@ -13,7 +13,8 @@ from Math64x61 import (
     Math64x61_exp,
     Math64x61_log2,
     Math64x61_ln,
-    Math64x61_log10
+    Math64x61_log10,
+    Math64x61_10xN_to_64x61
 )
 
 @view
@@ -92,5 +93,11 @@ end
 @view
 func Math64x61_log10_test {range_check_ptr} (x: felt) -> (res: felt):
     let (res) = Math64x61_log10(x)
+    return (res)
+end
+
+@view
+func Math64x61_10xN_to_64x61_test {range_check_ptr} (x: felt, decimals: felt) -> (res: felt):
+    let (res) = Math64x61_10xN_to_64x61(x, decimals)
     return (res)
 end

--- a/test/math64x61.spec.js
+++ b/test/math64x61.spec.js
@@ -134,7 +134,7 @@ describe('64.61 fixed point math', function () {
       expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
     }
   });
-  
+
   it('should return accurate results for binary log', async () => {
     const xs = [ 0.5, 0.75, 1, 2, 5, 72.11 ];
 
@@ -162,6 +162,24 @@ describe('64.61 fixed point math', function () {
       const { res } = await contract.call('Math64x61_log10_test', { x: to64x61(x) });
       const exp = Math.log10(x);
       expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
+    }
+  });
+
+  it('should return accurate results for converting price', async () => {
+    // test different magnitudes
+    const xs = [0.00123, 0.561, 1.58, 10.84, 153.10, 1571.11, 23560.33, 101542.73, 1723561.14];
+    const decimals = [5, 7, 10, 12, 15, 18]
+
+    for (const decimal of decimals){
+      for (const x of xs) {
+        const { res } = await contract.call(
+          'Math64x61_base10_to_64x61_test',
+          { x: toFelt(x * Math.pow(10, decimal)), decimals: toFelt(decimal) }
+
+        );
+        const exp = Math.trunc(x * Math.pow(2, 61));
+        expect(from64x61(res)).to.be.closeTo(x, ABS_TOL);
+      }
     }
   });
 });


### PR DESCRIPTION
This PR adds functions that help with using different oracles(https://www.stork.network/, https://empiric.network/, etc). These oracles return prices multiplied by 10**18 and converting these prices to the Math64x61 format can sometimes be quite tricky due to errors in overflow etc. 

Functions proposed here address this problem and can convert such prices to the desired Match64x61 format. Tests are provided as well. 