### PR TITLE
Function for converting oracles

### DIFF
--- a/contracts/cairo_math_64x61/math64x61.cairo
+++ b/contracts/cairo_math_64x61/math64x61.cairo
@@ -1,6 +1,7 @@
 from starkware.cairo.common.uint256 import Uint256
 from starkware.cairo.common.math_cmp import is_le, is_not_zero
 from starkware.cairo.common.pow import pow as pow_int
+from starkware.cairo.common.bool import TRUE, FALSE
 from starkware.cairo.common.math import (
     assert_le,
     assert_lt,
@@ -48,6 +49,36 @@ namespace Math64x61:
     func fromUint256 {range_check_ptr} (x: Uint256) -> (res: felt):
         assert x.high = 0
         let (res) = fromFelt(x.low)
+        return (res)
+    end
+
+    # Converts numbers multiplied by 10**n to Math64x61 format which are often returned by oracles
+    func fromOracles{range_check_ptr}(price : felt, decimals : felt) -> (price : felt):
+        alloc_locals
+        let (is_convertable) = is_le(price, INT_PART)
+
+        if is_convertable == TRUE:
+            let (converted_price) = fromFelt(price)
+            let (pow10xM) = pow(10, decimals)
+            let (pow10xM_to_64x61) = fromFelt(pow10xM)
+            let (price_64x61) = divImprecise(converted_price, pow10xM_to_64x61)
+            return (price_64x61)
+        end
+
+        let (decimals_1, r) = unsigned_div_rem(decimals, 2)
+        let decimals_2 = decimals - decimals_1
+
+        let (pow_10_m1) = pow(10, decimals_1)
+        let (c, remainder) = unsigned_div_rem(price, pow_10_m1)
+
+        let (a) = fromOracles(c, decimals_2)
+        let (b) = fromOracles(remainder, decimals)
+
+        let (res) = add(a, b)
+
+        # Outputs number in 64x61 format which might be
+        # slightly imprecise due to imprecise division,
+        # however tests are run to assert 5e-7 precision
         return (res)
     end
 
@@ -121,6 +152,29 @@ namespace Math64x61:
         let (res_u, _) = signed_div_rem(product, div, BOUND)
         assert64x61(res_u)
         return (res = res_u * div_sign)
+    end
+
+    # Function for iterative division, which can prevent weird errors in overflow,
+    # granted it may introduce an imprecision to the result.
+    func divImprecise{range_check_ptr}(x : felt, y : felt) -> (res : felt):
+        alloc_locals
+
+        let (pow_10_to_30) = pow(10, 30)
+        let (is_convertable) = is_le(y, pow_10_to_30)
+        if is_convertable == TRUE:
+            let (res_a) = div(x, y)
+            return (res_a)
+        end
+
+        # div a and b calculated differently due to imprecision
+        let (div_a) = sqrt(y)
+        let (div_b) = div(y, div_a)
+
+        # x / y = x / ( sqrt(y) * sqrt(y) )
+        let (partial_res) = divImprecise(x, div_a)
+        let (res) = divImprecise(partial_res, div_b)
+
+        return (res)
     end
 
     # Calclates the value of x^y and checks for overflow before returning

--- a/contracts/cairo_math_64x61/math64x61.cairo
+++ b/contracts/cairo_math_64x61/math64x61.cairo
@@ -1,7 +1,6 @@
 from starkware.cairo.common.uint256 import Uint256
 from starkware.cairo.common.math_cmp import is_le, is_not_zero
 from starkware.cairo.common.pow import pow as pow_int
-from starkware.cairo.common.bool import TRUE, FALSE
 from starkware.cairo.common.math import (
     assert_le,
     assert_lt,
@@ -57,9 +56,9 @@ namespace Math64x61:
         alloc_locals
         let (is_convertable) = is_le(price, INT_PART)
 
-        if is_convertable == TRUE:
+        if is_convertable == 1:
             let (converted_price) = fromFelt(price)
-            let (pow10xM) = pow(10, decimals)
+            let (pow10xM) = pow_int(10, decimals)
             let (pow10xM_to_64x61) = fromFelt(pow10xM)
             let (price_64x61) = divImprecise(converted_price, pow10xM_to_64x61)
             return (price_64x61)
@@ -68,7 +67,7 @@ namespace Math64x61:
         let (decimals_1, r) = unsigned_div_rem(decimals, 2)
         let decimals_2 = decimals - decimals_1
 
-        let (pow_10_m1) = pow(10, decimals_1)
+        let (pow_10_m1) = pow_int(10, decimals_1)
         let (c, remainder) = unsigned_div_rem(price, pow_10_m1)
 
         let (a) = fromOracles(c, decimals_2)
@@ -159,9 +158,9 @@ namespace Math64x61:
     func divImprecise{range_check_ptr}(x : felt, y : felt) -> (res : felt):
         alloc_locals
 
-        let (pow_10_to_30) = pow(10, 30)
+        let (pow_10_to_30) = pow_int(10, 30)
         let (is_convertable) = is_le(y, pow_10_to_30)
-        if is_convertable == TRUE:
+        if is_convertable == 1:
             let (res_a) = div(x, y)
             return (res_a)
         end

--- a/contracts/cairo_math_64x61/math64x61_mock.cairo
+++ b/contracts/cairo_math_64x61/math64x61_mock.cairo
@@ -80,3 +80,9 @@ func math64x61_log10_test {range_check_ptr} (x: felt) -> (res: felt):
     let (res) = Math64x61.log10(x)
     return (res)
 end
+
+@view
+func math64x61_fromOracles_test {range_check_ptr} (x: felt, decimals: felt) -> (res: felt):
+    let (res) = Math64x61.fromOracles(x, decimals)
+    return (res)
+end

--- a/test/math64x61.spec.js
+++ b/test/math64x61.spec.js
@@ -17,186 +17,169 @@ describe('64.61 fixed point math', function () {
     contract = await contractFactory.deploy();
   });
 
-  // it('should return accurate results for floor', async () => {
-  //   const count = 10;
-  //   const xs = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
-
-  //   for (const x of xs) {
-  //     const { res } = await contract.call('math64x61_floor_test', { x: to64x61(x) });
-  //     const exp = Math.floor(x);
-  //     expect(from64x61(res)).to.eq(exp);
-  //   }
-  // });
-
-  // it('should return accurate results for ceiling', async () => {
-  //   const count = 10;
-  //   const xs = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
-
-  //   for (const x of xs) {
-  //     const { res } = await contract.call('math64x61_ceil_test', { x: to64x61(x) });
-  //     const exp = Math.ceil(x);
-  //     expect(from64x61(res)).to.eq(exp);
-  //   }
-  // });
-
-  // it('should return accurate results for min', async () => {
-  //   const count = 10;
-  //   const xs = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
-  //   const ys = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
-
-  //   for (const [ i, x ] of xs.entries()) {
-  //     const y = ys[i];
-  //     const { res } = await contract.call('math64x61_min_test', { x: to64x61(x), y: to64x61(y) });
-  //     const exp = Math.min(x, y);
-  //     expect(from64x61(res)).to.eq(exp);
-  //   }
-  // });
-
-  // it('should return accurate results for max', async () => {
-  //   const count = 10;
-  //   const xs = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
-  //   const ys = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
-
-  //   for (const [ i, x ] of xs.entries()) {
-  //     const y = ys[i];
-  //     const { res } = await contract.call('math64x61_max_test', { x: to64x61(x), y: to64x61(y) });
-  //     const exp = Math.max(x, y);
-  //     expect(from64x61(res)).to.eq(exp);
-  //   }
-  // });
-
-  // it('should return accurate results for multiplication', async () => {
-  //   const count = 10;
-  //   const xs = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
-  //   const ys = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
-
-  //   for (const [ i, x ] of xs.entries()) {
-  //     const y = ys[i];
-  //     const { res } = await contract.call('math64x61_mul_test', {
-  //       x: to64x61(x),
-  //       y: to64x61(y)
-  //     });
-
-  //     const exp = x * y;
-  //     expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
-  //   }
-  // });
-
-  // it('should return accurate results for division', async () => {
-  //   const count = 10;
-  //   const xs = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
-  //   const ys = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
-
-  //   for (const [ i, x ] of xs.entries()) {
-  //     const y = ys[i];
-  //     const { res } = await contract.call('math64x61_div_test', {
-  //       x: to64x61(x),
-  //       y: to64x61(y)
-  //     });
-
-  //     const exp = x / y;
-  //     expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
-  //   }
-  // });
-
-  // it('should return accurate results for powers', async () => {
-  //   const xs = [ 4, 4, 4 , 1024, 2 ** 16 - 1 , 4 , 64, -10, -10, -10, 0.5, 0.25, 0.125 ];
-  //   const ys = [ 0, 1, 2 , 3, 3 , -2, -3, 1, 2, 3, 0.5, 1, 1.5 ];
-
-  //   for (const [ i, x ] of xs.entries()) {
-  //     const y = ys[i];
-  //     const { res } = await contract.call('math64x61_pow_test', {
-  //       x: to64x61(x),
-  //       y: to64x61(y)
-  //     });
-
-  //     const exp = x ** y;
-  //     expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
-  //   }
-  // });
-
-  // it('should return accurate results for sqrt', async () => {
-  //   const xs = [ 1, 64, 2 ** 32, 7.21 ** 2 ];
-
-  //   for (const x of xs) {
-  //     const { res } = await contract.call('math64x61_sqrt_test', { x: to64x61(x) });
-  //     const exp = Math.sqrt(x);
-  //     expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
-  //   }
-  // });
-
-  // it('should return accurate results for binary exponent', async () => {
-  //   const xs = [ 0, 1, 3, 5.5, -1, -5.5 ];
-
-  //   for (const x of xs) {
-  //     const { res } = await contract.call('math64x61_exp2_test', { x: to64x61(x) });
-  //     const exp = 2 ** x;
-  //     expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
-  //   }
-  // });
-
-  // it('should return accurate results for binary log', async () => {
-  //   const xs = [ 0.5, 0.75, 1, 2, 5, 72.11 ];
-
-  //   for (const x of xs) {
-  //     const { res } = await contract.call('math64x61_log2_test', { x: to64x61(x) });
-  //     const exp = Math.log2(x);
-  //     expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
-  //   }
-  // });
-
-  // it('should return accurate results for natural log', async () => {
-  //   const xs = [ 0.5, 1, Math.E, 5, 72.11 ];
-
-  //   for (const x of xs) {
-  //     const { res } = await contract.call('math64x61_ln_test', { x: to64x61(x) });
-  //     const exp = Math.log(x);
-  //     expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
-  //   }
-  // });
-
-  // it('should return accurate results for base10 log', async () => {
-  //   const xs = [ 0.5, 1, 2, 10, 72.11 ];
-
-  //   for (const x of xs) {
-  //     const { res } = await contract.call('math64x61_log10_test', { x: to64x61(x) });
-  //     const exp = Math.log10(x);
-  //     expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
-  //   }
-  // });
-
-
-  it('should return accurate results for converting price', async () => {
-    // test different magnitudes
-    // const xs = [0.00123, 0.561, 1.58, 10.84, 153.10, 1571.11, 23560.33, 101542.73, 1723561.14];
-    const xs = [1.50, 10, 128];
-    // const decimals = [5, 7, 10, 12, 15, 18]
-    const decimal = 18
-
+  it('should return accurate results for floor', async () => {
+    const count = 10;
+    const xs = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
 
     for (const x of xs) {
-      const { res } = await contract.call(
-        'math64x61_fromOracles_test',
-        { x: toFelt(x * Math.pow(10, 18)), decimals: toFelt(decimal) }
-
-      );
-      const exp = Math.trunc(x * Math.pow(2, 61));
-      expect(from64x61(res)).to.be.closeTo(x, ABS_TOL);
+      const { res } = await contract.call('math64x61_floor_test', { x: to64x61(x) });
+      const exp = Math.floor(x);
+      expect(from64x61(res)).to.eq(exp);
     }
+  });
 
+  it('should return accurate results for ceiling', async () => {
+    const count = 10;
+    const xs = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
 
+    for (const x of xs) {
+      const { res } = await contract.call('math64x61_ceil_test', { x: to64x61(x) });
+      const exp = Math.ceil(x);
+      expect(from64x61(res)).to.eq(exp);
+    }
+  });
 
-  //   for (const decimal of decimals){
-  //     for (const x of xs) {
-  //       const { res } = await contract.call(
-  //         'math64x61_fromOracles_test',
-  //         { x: toFelt(x * Math.pow(10, decimal)), decimals: decimal }
+  it('should return accurate results for min', async () => {
+    const count = 10;
+    const xs = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
+    const ys = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
 
-  //       );
-  //       const exp = Math.trunc(x * Math.pow(2, 61));
-  //       expect(from64x61(res)).to.be.closeTo(x, ABS_TOL);
-  //     }
-  //   }
+    for (const [ i, x ] of xs.entries()) {
+      const y = ys[i];
+      const { res } = await contract.call('math64x61_min_test', { x: to64x61(x), y: to64x61(y) });
+      const exp = Math.min(x, y);
+      expect(from64x61(res)).to.eq(exp);
+    }
+  });
+
+  it('should return accurate results for max', async () => {
+    const count = 10;
+    const xs = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
+    const ys = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
+
+    for (const [ i, x ] of xs.entries()) {
+      const y = ys[i];
+      const { res } = await contract.call('math64x61_max_test', { x: to64x61(x), y: to64x61(y) });
+      const exp = Math.max(x, y);
+      expect(from64x61(res)).to.eq(exp);
+    }
+  });
+
+  it('should return accurate results for multiplication', async () => {
+    const count = 10;
+    const xs = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
+    const ys = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
+
+    for (const [ i, x ] of xs.entries()) {
+      const y = ys[i];
+      const { res } = await contract.call('math64x61_mul_test', {
+        x: to64x61(x),
+        y: to64x61(y)
+      });
+
+      const exp = x * y;
+      expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
+    }
+  });
+
+  it('should return accurate results for division', async () => {
+    const count = 10;
+    const xs = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
+    const ys = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
+
+    for (const [ i, x ] of xs.entries()) {
+      const y = ys[i];
+      const { res } = await contract.call('math64x61_div_test', {
+        x: to64x61(x),
+        y: to64x61(y)
+      });
+
+      const exp = x / y;
+      expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
+    }
+  });
+
+  it('should return accurate results for powers', async () => {
+    const xs = [ 4, 4, 4 , 1024, 2 ** 16 - 1 , 4 , 64, -10, -10, -10, 0.5, 0.25, 0.125 ];
+    const ys = [ 0, 1, 2 , 3, 3 , -2, -3, 1, 2, 3, 0.5, 1, 1.5 ];
+
+    for (const [ i, x ] of xs.entries()) {
+      const y = ys[i];
+      const { res } = await contract.call('math64x61_pow_test', {
+        x: to64x61(x),
+        y: to64x61(y)
+      });
+
+      const exp = x ** y;
+      expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
+    }
+  });
+
+  it('should return accurate results for sqrt', async () => {
+    const xs = [ 1, 64, 2 ** 32, 7.21 ** 2 ];
+
+    for (const x of xs) {
+      const { res } = await contract.call('math64x61_sqrt_test', { x: to64x61(x) });
+      const exp = Math.sqrt(x);
+      expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
+    }
+  });
+
+  it('should return accurate results for binary exponent', async () => {
+    const xs = [ 0, 1, 3, 5.5, -1, -5.5 ];
+
+    for (const x of xs) {
+      const { res } = await contract.call('math64x61_exp2_test', { x: to64x61(x) });
+      const exp = 2 ** x;
+      expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
+    }
+  });
+
+  it('should return accurate results for binary log', async () => {
+    const xs = [ 0.5, 0.75, 1, 2, 5, 72.11 ];
+
+    for (const x of xs) {
+      const { res } = await contract.call('math64x61_log2_test', { x: to64x61(x) });
+      const exp = Math.log2(x);
+      expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
+    }
+  });
+
+  it('should return accurate results for natural log', async () => {
+    const xs = [ 0.5, 1, Math.E, 5, 72.11 ];
+
+    for (const x of xs) {
+      const { res } = await contract.call('math64x61_ln_test', { x: to64x61(x) });
+      const exp = Math.log(x);
+      expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
+    }
+  });
+
+  it('should return accurate results for base10 log', async () => {
+    const xs = [ 0.5, 1, 2, 10, 72.11 ];
+
+    for (const x of xs) {
+      const { res } = await contract.call('math64x61_log10_test', { x: to64x61(x) });
+      const exp = Math.log10(x);
+      expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
+    }
+  });
+
+  it('should return accurate results for converting price', async () => {
+    const xs = [0.00123, 0.561, 1.58, 10.84, 153.10, 1571.11, 23560.33, 101542.73, 1723561.14];
+    const decimals = [5, 7, 10, 12, 15, 18]
+
+    for (const decimal of decimals){
+      for (const x of xs) {
+        const { res } = await contract.call(
+          'math64x61_fromOracles_test',
+          { x: toFelt(x * Math.pow(10, decimal)), decimals: decimal }
+        );
+
+        const exp = Math.trunc(x * Math.pow(2, 61));
+        expect(from64x61(res)).to.be.closeTo(x, ABS_TOL);
+      }
+    }
 
   });
 

--- a/test/math64x61.spec.js
+++ b/test/math64x61.spec.js
@@ -177,7 +177,7 @@ describe('64.61 fixed point math', function () {
         );
 
         const exp = Math.trunc(x * Math.pow(2, 61));
-        expect(from64x61(res)).to.be.closeTo(x, ABS_TOL);
+        expect(from64x61(res)).to.be.closeTo(x, 5e-15);
       }
     }
 

--- a/test/math64x61.spec.js
+++ b/test/math64x61.spec.js
@@ -17,151 +17,187 @@ describe('64.61 fixed point math', function () {
     contract = await contractFactory.deploy();
   });
 
-  it('should return accurate results for floor', async () => {
-    const count = 10;
-    const xs = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
+  // it('should return accurate results for floor', async () => {
+  //   const count = 10;
+  //   const xs = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
+
+  //   for (const x of xs) {
+  //     const { res } = await contract.call('math64x61_floor_test', { x: to64x61(x) });
+  //     const exp = Math.floor(x);
+  //     expect(from64x61(res)).to.eq(exp);
+  //   }
+  // });
+
+  // it('should return accurate results for ceiling', async () => {
+  //   const count = 10;
+  //   const xs = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
+
+  //   for (const x of xs) {
+  //     const { res } = await contract.call('math64x61_ceil_test', { x: to64x61(x) });
+  //     const exp = Math.ceil(x);
+  //     expect(from64x61(res)).to.eq(exp);
+  //   }
+  // });
+
+  // it('should return accurate results for min', async () => {
+  //   const count = 10;
+  //   const xs = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
+  //   const ys = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
+
+  //   for (const [ i, x ] of xs.entries()) {
+  //     const y = ys[i];
+  //     const { res } = await contract.call('math64x61_min_test', { x: to64x61(x), y: to64x61(y) });
+  //     const exp = Math.min(x, y);
+  //     expect(from64x61(res)).to.eq(exp);
+  //   }
+  // });
+
+  // it('should return accurate results for max', async () => {
+  //   const count = 10;
+  //   const xs = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
+  //   const ys = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
+
+  //   for (const [ i, x ] of xs.entries()) {
+  //     const y = ys[i];
+  //     const { res } = await contract.call('math64x61_max_test', { x: to64x61(x), y: to64x61(y) });
+  //     const exp = Math.max(x, y);
+  //     expect(from64x61(res)).to.eq(exp);
+  //   }
+  // });
+
+  // it('should return accurate results for multiplication', async () => {
+  //   const count = 10;
+  //   const xs = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
+  //   const ys = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
+
+  //   for (const [ i, x ] of xs.entries()) {
+  //     const y = ys[i];
+  //     const { res } = await contract.call('math64x61_mul_test', {
+  //       x: to64x61(x),
+  //       y: to64x61(y)
+  //     });
+
+  //     const exp = x * y;
+  //     expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
+  //   }
+  // });
+
+  // it('should return accurate results for division', async () => {
+  //   const count = 10;
+  //   const xs = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
+  //   const ys = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
+
+  //   for (const [ i, x ] of xs.entries()) {
+  //     const y = ys[i];
+  //     const { res } = await contract.call('math64x61_div_test', {
+  //       x: to64x61(x),
+  //       y: to64x61(y)
+  //     });
+
+  //     const exp = x / y;
+  //     expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
+  //   }
+  // });
+
+  // it('should return accurate results for powers', async () => {
+  //   const xs = [ 4, 4, 4 , 1024, 2 ** 16 - 1 , 4 , 64, -10, -10, -10, 0.5, 0.25, 0.125 ];
+  //   const ys = [ 0, 1, 2 , 3, 3 , -2, -3, 1, 2, 3, 0.5, 1, 1.5 ];
+
+  //   for (const [ i, x ] of xs.entries()) {
+  //     const y = ys[i];
+  //     const { res } = await contract.call('math64x61_pow_test', {
+  //       x: to64x61(x),
+  //       y: to64x61(y)
+  //     });
+
+  //     const exp = x ** y;
+  //     expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
+  //   }
+  // });
+
+  // it('should return accurate results for sqrt', async () => {
+  //   const xs = [ 1, 64, 2 ** 32, 7.21 ** 2 ];
+
+  //   for (const x of xs) {
+  //     const { res } = await contract.call('math64x61_sqrt_test', { x: to64x61(x) });
+  //     const exp = Math.sqrt(x);
+  //     expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
+  //   }
+  // });
+
+  // it('should return accurate results for binary exponent', async () => {
+  //   const xs = [ 0, 1, 3, 5.5, -1, -5.5 ];
+
+  //   for (const x of xs) {
+  //     const { res } = await contract.call('math64x61_exp2_test', { x: to64x61(x) });
+  //     const exp = 2 ** x;
+  //     expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
+  //   }
+  // });
+
+  // it('should return accurate results for binary log', async () => {
+  //   const xs = [ 0.5, 0.75, 1, 2, 5, 72.11 ];
+
+  //   for (const x of xs) {
+  //     const { res } = await contract.call('math64x61_log2_test', { x: to64x61(x) });
+  //     const exp = Math.log2(x);
+  //     expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
+  //   }
+  // });
+
+  // it('should return accurate results for natural log', async () => {
+  //   const xs = [ 0.5, 1, Math.E, 5, 72.11 ];
+
+  //   for (const x of xs) {
+  //     const { res } = await contract.call('math64x61_ln_test', { x: to64x61(x) });
+  //     const exp = Math.log(x);
+  //     expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
+  //   }
+  // });
+
+  // it('should return accurate results for base10 log', async () => {
+  //   const xs = [ 0.5, 1, 2, 10, 72.11 ];
+
+  //   for (const x of xs) {
+  //     const { res } = await contract.call('math64x61_log10_test', { x: to64x61(x) });
+  //     const exp = Math.log10(x);
+  //     expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
+  //   }
+  // });
+
+
+  it('should return accurate results for converting price', async () => {
+    // test different magnitudes
+    // const xs = [0.00123, 0.561, 1.58, 10.84, 153.10, 1571.11, 23560.33, 101542.73, 1723561.14];
+    const xs = [1.50, 10, 128];
+    // const decimals = [5, 7, 10, 12, 15, 18]
+    const decimal = 18
+
 
     for (const x of xs) {
-      const { res } = await contract.call('math64x61_floor_test', { x: to64x61(x) });
-      const exp = Math.floor(x);
-      expect(from64x61(res)).to.eq(exp);
+      const { res } = await contract.call(
+        'math64x61_fromOracles_test',
+        { x: toFelt(x * Math.pow(10, 18)), decimals: toFelt(decimal) }
+
+      );
+      const exp = Math.trunc(x * Math.pow(2, 61));
+      expect(from64x61(res)).to.be.closeTo(x, ABS_TOL);
     }
+
+
+
+  //   for (const decimal of decimals){
+  //     for (const x of xs) {
+  //       const { res } = await contract.call(
+  //         'math64x61_fromOracles_test',
+  //         { x: toFelt(x * Math.pow(10, decimal)), decimals: decimal }
+
+  //       );
+  //       const exp = Math.trunc(x * Math.pow(2, 61));
+  //       expect(from64x61(res)).to.be.closeTo(x, ABS_TOL);
+  //     }
+  //   }
+
   });
 
-  it('should return accurate results for ceiling', async () => {
-    const count = 10;
-    const xs = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
-
-    for (const x of xs) {
-      const { res } = await contract.call('math64x61_ceil_test', { x: to64x61(x) });
-      const exp = Math.ceil(x);
-      expect(from64x61(res)).to.eq(exp);
-    }
-  });
-
-  it('should return accurate results for min', async () => {
-    const count = 10;
-    const xs = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
-    const ys = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
-
-    for (const [ i, x ] of xs.entries()) {
-      const y = ys[i];
-      const { res } = await contract.call('math64x61_min_test', { x: to64x61(x), y: to64x61(y) });
-      const exp = Math.min(x, y);
-      expect(from64x61(res)).to.eq(exp);
-    }
-  });
-
-  it('should return accurate results for max', async () => {
-    const count = 10;
-    const xs = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
-    const ys = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
-
-    for (const [ i, x ] of xs.entries()) {
-      const y = ys[i];
-      const { res } = await contract.call('math64x61_max_test', { x: to64x61(x), y: to64x61(y) });
-      const exp = Math.max(x, y);
-      expect(from64x61(res)).to.eq(exp);
-    }
-  });
-
-  it('should return accurate results for multiplication', async () => {
-    const count = 10;
-    const xs = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
-    const ys = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
-
-    for (const [ i, x ] of xs.entries()) {
-      const y = ys[i];
-      const { res } = await contract.call('math64x61_mul_test', {
-        x: to64x61(x),
-        y: to64x61(y)
-      });
-      
-      const exp = x * y;
-      expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
-    }
-  });
-
-  it('should return accurate results for division', async () => {
-    const count = 10;
-    const xs = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
-    const ys = Array.from({ length: count }, () => Math.random() * 2 ** 32 - 2 ** 31);
-
-    for (const [ i, x ] of xs.entries()) {
-      const y = ys[i];
-      const { res } = await contract.call('math64x61_div_test', {
-        x: to64x61(x),
-        y: to64x61(y)
-      });
-      
-      const exp = x / y;
-      expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
-    }
-  });
-
-  it('should return accurate results for powers', async () => {
-    const xs = [ 4, 4, 4 , 1024, 2 ** 16 - 1 , 4 , 64, -10, -10, -10, 0.5, 0.25, 0.125 ];
-    const ys = [ 0, 1, 2 , 3, 3 , -2, -3, 1, 2, 3, 0.5, 1, 1.5 ];
-
-    for (const [ i, x ] of xs.entries()) {
-      const y = ys[i];
-      const { res } = await contract.call('math64x61_pow_test', {
-        x: to64x61(x),
-        y: to64x61(y)
-      });
-
-      const exp = x ** y;
-      expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
-    }
-  });
-  
-  it('should return accurate results for sqrt', async () => {
-    const xs = [ 1, 64, 2 ** 32, 7.21 ** 2 ];
-
-    for (const x of xs) {
-      const { res } = await contract.call('math64x61_sqrt_test', { x: to64x61(x) });
-      const exp = Math.sqrt(x);
-      expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
-    }
-  });
-
-  it('should return accurate results for binary exponent', async () => {
-    const xs = [ 0, 1, 3, 5.5, -1, -5.5 ];
-
-    for (const x of xs) {
-      const { res } = await contract.call('math64x61_exp2_test', { x: to64x61(x) });
-      const exp = 2 ** x;
-      expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
-    }
-  });
-  
-  it('should return accurate results for binary log', async () => {
-    const xs = [ 0.5, 0.75, 1, 2, 5, 72.11 ];
-
-    for (const x of xs) {
-      const { res } = await contract.call('math64x61_log2_test', { x: to64x61(x) });
-      const exp = Math.log2(x);
-      expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
-    }
-  });
-
-  it('should return accurate results for natural log', async () => {
-    const xs = [ 0.5, 1, Math.E, 5, 72.11 ];
-
-    for (const x of xs) {
-      const { res } = await contract.call('math64x61_ln_test', { x: to64x61(x) });
-      const exp = Math.log(x);
-      expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
-    }
-  });
-
-  it('should return accurate results for base10 log', async () => {
-    const xs = [ 0.5, 1, 2, 10, 72.11 ];
-
-    for (const x of xs) {
-      const { res } = await contract.call('math64x61_log10_test', { x: to64x61(x) });
-      const exp = Math.log10(x);
-      expect(almost(from64x61(res), exp, ABS_TOL, REL_TOL), `${from64x61(res)} != ${exp}`).to.be.true;
-    }
-  });
 });


### PR DESCRIPTION
Starknet oracles (Empiric network, Stork etc.) provide prices of assets multiplied by 10^18. This can present a challenge when we want to end with price multiplied by 2**61 instead, due to overflow etc. For this reason, I'd like to add a function that manages to convert such prices to the Math64x61 format. Tested to 5e-15 precision. 